### PR TITLE
Added option to configure the UI language per user

### DIFF
--- a/multilingual/conf/default.php
+++ b/multilingual/conf/default.php
@@ -8,4 +8,5 @@ $conf['use_browser_lang'] =  true; // Check browser ui for language setting.
 $conf['start_redirect']   = false; // Redirect to the language start parge
 $conf['skiptrans']        = '';
 $conf['about']            = '';
+$conf['user_settings']    = '';
 

--- a/multilingual/conf/metadata.php
+++ b/multilingual/conf/metadata.php
@@ -11,4 +11,5 @@ $meta['use_browser_lang']  = array('onoff');
 $meta['start_redirect']    = array('onoff');
 $meta['skiptrans']         = array('string');
 $meta['about']             = array('string','_pattern' => '/^(|[\w:\-]+)$/');
+$meta['user_settings']     = array('');
 ?>


### PR DESCRIPTION
This is an attempt to enable configuration of the UI language per user. Also see forum thread https://forum.dokuwiki.org/thread/16576.

If the logged in user has got a settings in ```user_settings``` then that language will be used. Otherwise normal processing continues (...check option ```use_browser_lang```).

Here is a example configuration for ```user_settings``` (it is a multi line text field):
```
UserA="de";
UserB="fr";
```
So in this example, if UserA logs in, the UI will be presented in german. If UserB logs in, the UI will be presented in french. If some different user logs in or if no one is logged in the plugin will act as before.