### PR TITLE
fix syntax for new dokuwiki

### DIFF
--- a/multilingual/syntax.php
+++ b/multilingual/syntax.php
@@ -58,14 +58,14 @@ class syntax_plugin_multilingual extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         return array('notrans');
     }
 
     /**
      * Create output
      */
-    function render($format, &$renderer, $data) {
+    function render($format, Doku_Renderer $renderer, $data) {
         // store info in metadata
         if($format == 'metadata'){
             $renderer->meta['plugin']['multilingual']['notrans'] = true;


### PR DESCRIPTION
Newer dokuwiki versions throw Fatal error on multiple places of action.php and syntax.php such as

Fatal error: Declaration of action_plugin_multilingual::register(&$controller) must be compatible with dokuwiki\Extension\ActionPlugin::register(Doku_Event_Handler $controller) ...

This patch replaces two instances of problematic code with the "compatible" implementation in newer dokuwiki:

Doku_Handler, Doku_Renderer